### PR TITLE
fix: SET NAMES execute error in backend conn

### DIFF
--- a/pkg/proxy/backend/connpool.go
+++ b/pkg/proxy/backend/connpool.go
@@ -159,7 +159,7 @@ func (cw *noErrorCloseConnWrapper) Close() {
 
 var noValueSysVars = map[string]*ast.VariableAssignment{}
 
-const RestoreSetVariableFlags = format.RestoreStringSingleQuotes | format.RestoreKeyWordUppercase
+const RestoreSetVariableFlags = format.RestoreStringSingleQuotes
 
 func getSysVarsFromCtx(ctx context.Context) map[string]*ast.VariableAssignment {
 	v := ctx.Value(constant.ContextKeySessionVariable)


### PR DESCRIPTION
<!--
Thank you for working on Weir! Please read Weir's [CONTRIBUTING](https://github.com/pingcap-incubator/weir/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

when execute "SET NAMES utf8mb4", the SQL is parsed and then restored in backend conn. But the restore flag is set to uppercase mode, so that the SetNAMES value cannot be correctly handled by the restore function.
